### PR TITLE
Notify changes done in a single object

### DIFF
--- a/Source/RealmExtension.swift
+++ b/Source/RealmExtension.swift
@@ -9,6 +9,32 @@
 import Foundation
 import RealmSwift
 
+extension Object {
+    
+    /**
+    Use this func to notify the RRC of changes done in a specific object.
+    Useful when you modify an object inside a write transaction but without doing an `add` or `create` action like:
+    
+    ```
+    let user = User()
+    user.name = "old name"
+    
+    realm.write {
+        realm.add(user)
+    }
+    
+    realm.write {
+        user.name = "new name"
+        user.notifyChange()
+    }
+    ```
+    */
+    public func notifyChange() {
+        guard let r = self.realm else { return }
+        RealmNotification.loggerForRealm(r).didUpdate(self)
+    }
+}
+
 extension Realm {
     
     //MARK: Add


### PR DESCRIPTION
Added a new `Object` extension that allows the user to notify changes done in a single realm object.

Useful when you modify an object inside a write transaction without calling any of the `add` or `create` custom methods.

Example of use:

``` swift
    let user = User()
    user.name = "old name"

    realm.write {
        realm.addNotified(user)
    }

    realm.write {
        user.name = "new name"
        user.notifyChange()
    }
```
