### PR TITLE
Defend against lazy vars when mirroring

### DIFF
--- a/Example/RealmResultsController/ViewModels.swift
+++ b/Example/RealmResultsController/ViewModels.swift
@@ -21,6 +21,10 @@ class TaskObject: Object {
         return "id"
     }
     
+    lazy var something: Bool = {
+        true
+    }()
+    
     static func map(model: TaskModelObject) -> TaskObject {
         let task = TaskObject()
         task.id = model.id
@@ -50,6 +54,10 @@ class TaskModelObject: Object {
     override static func primaryKey() -> String? {
         return "id"
     }
+    
+    lazy var something: Bool = {
+        true
+    }()
 }
 
 class UserObject: Object {

--- a/Source/RealmExtension.swift
+++ b/Source/RealmExtension.swift
@@ -197,6 +197,7 @@ func getMirror<T: Object>(object: T) -> T {
     let mirror = Mirror(reflecting: object)
     for c in mirror.children.enumerate() {
         let key = c.1.0!
+        guard !key.hasSuffix(".storage") else { continue }
         let value = (object as Object).valueForKey(key)
         guard let v = value else { continue }
         (newObject as Object).setValue(v, forKey: key)


### PR DESCRIPTION
#### :tophat: What? Why?

When an object has lazy vars, you can't (and shouldn't) mirror it. Swift adds the ".storage" suffix to lazy vars. 

Ignore lazy vars when mirroring
#### :dart: What should QA test?
#### :pushpin: Related tasks?
#### :clipboard: Developer checklist
- [ ] Unit Tests (if necessary)
- [ ] UI Snapshot Tests (if necessary)
- [ ] Added accessibility tags to any interactive element
- [ ] Added reporting for GA (events + screen views) / Errors / Exceptions
- [ ] Documentation
#### :ghost: GIF

![]()
