### PR TITLE
External Cartfile for RRC Dependencies when using Carthage

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "realm/realm-cocoa" "v0.95.3"


### PR DESCRIPTION
#### :tophat: What? Why?

When adding RealmResultsController through `carthage`, it was not finding its dependencies as the Cartfile was in `/Example/Cartfile`.

Added a External Cartfile in the RRC root folder for carthage to be able to find RRC dependencies
#### :ghost: GIF

![](http://i.giphy.com/ypHVUhC2UmqoU.gif)
