### PR TITLE
Crash on endUpdates when using Filters

### DIFF
--- a/Source/RealmResultsController.swift
+++ b/Source/RealmResultsController.swift
@@ -308,7 +308,12 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
                 temporaryAdded.append(object.mirror as! T)
             }
             else if object.action == RealmAction.Update {
-                passesPredicate ? temporaryUpdated.append(object.mirror as! T) : temporaryDeleted.append(object.mirror as! T)
+                if passesFilter && passesPredicate {
+                    temporaryUpdated.append(object.mirror as! T)
+                }
+                else {
+                    temporaryDeleted.append(object.mirror as! T)
+                }
             }
         }
     }


### PR DESCRIPTION
#### :tophat: What? Why?

There was a crash in the `endUpdates()` of a tableView when using filter in RRC. 
We were not ignoring update notifications for objects that are not passing the filter.

This should now be fixed
#### :ghost: GIF

![](http://i.giphy.com/soitAQThr9FOU.gif)
