### PR TITLE
Queue manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,5 @@ Podfile.lock
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-Example/Carthage/Checkouts/
-Example/Carthage/Build/
+Carthage/Checkouts/
+Carthage/Build/

--- a/Example/RealmResultsController-iOSTests/RealmQueueManager.swift
+++ b/Example/RealmResultsController-iOSTests/RealmQueueManager.swift
@@ -1,0 +1,122 @@
+//
+//  RealmQueueManager.swift
+//  RealmResultsController
+//
+//  Created by Pol Quintana on 10/12/15.
+//  Copyright © 2015 Redbooth. All rights reserved.
+//
+
+import Foundation
+import Quick
+import Nimble
+
+@testable import RealmResultsController
+
+private let blocksTimeout: UInt32 = 1
+
+class RealmQueueManagerSpec: QuickSpec {
+    private var queueManager = RealmQueueManager()
+    private var thread1BlockHasBeenFired = false
+    private var thread2BlockHasBeenFired = false
+    private var timeoutHasBeenReached = false
+    
+    func fireThread1Block() {
+        let queue = dispatch_queue_create("THREAD 1", DISPATCH_QUEUE_SERIAL)
+        Threading.executeOnQueue(queue, sync: true) {
+            self.queueManager.addOperation {
+                self.thread1BlockHasBeenFired = true
+                sleep(2)
+            }
+        }
+    }
+    
+    func fireThread2Block() {
+        let queue = dispatch_queue_create("THREAD 2", DISPATCH_QUEUE_SERIAL)
+        Threading.executeOnQueue(queue, sync: true) {
+            self.queueManager.addOperation {
+                self.thread2BlockHasBeenFired = true
+                sleep(2)
+            }
+        }
+    }
+    
+    func oneBlockFired() -> Bool {
+        let a = self.thread1BlockHasBeenFired || self.thread2BlockHasBeenFired
+        return a && !(self.thread1BlockHasBeenFired && self.thread2BlockHasBeenFired)
+    }
+    
+    override func spec() {
+        context("addOperation(withBlock:)") {
+            context("enqueued operations") {
+                let queueManager = RealmQueueManager(serial: false)
+                var block1Executed = false
+                var block2Executed = false
+                let block1 = {
+                    block1Executed = true
+                    sleep(blocksTimeout)
+                }
+                let block2 = {
+                    block2Executed = true
+                    sleep(blocksTimeout)
+                }
+                beforeEach {
+                    queueManager.addOperation(withBlock: block1)
+                    queueManager.addOperation(withBlock: block2)
+                }
+                afterEach {
+                    block1Executed = false
+                    block2Executed = false
+                }
+                it("should have executed the block 1") {
+                    expect(block1Executed).toEventually(beTruthy())
+                }
+                it("should have enqueued the execution of the block 2") {
+                    expect(block2Executed).toEventually(beFalsy())
+                }
+                it("should have executed the block 2 when reaching the 5 seconds timeout") {
+                    expect(block2Executed).toEventually(beTruthy(), timeout: 5)
+                }
+            }
+            context("serial operations") {
+                let queueManager = RealmQueueManager(serial: true)
+                var block1Executed = false
+                var block2Executed = false
+                let block1 = {
+                    block1Executed = true
+                    sleep(blocksTimeout)
+                }
+                let block2 = {
+                    block2Executed = true
+                    sleep(blocksTimeout)
+                }
+                beforeEach {
+                    queueManager.addOperation(withBlock: block1)
+                    queueManager.addOperation(withBlock: block2)
+                }
+                afterEach {
+                    block1Executed = false
+                    block2Executed = false
+                }
+                it("should have instantly executed the block 1") {
+                    expect(block1Executed).to(beTruthy())
+                }
+                it("should have NOT enqueued the execution of the block 2") {
+                    expect(block2Executed).to(beTruthy())
+                }
+            }
+            
+            context("equeued operations from different threads") {
+                beforeEach {
+                    let date = NSDate().dateByAddingTimeInterval(1)
+                    let timer1 = NSTimer(fireDate: date, interval: 0, target: self, selector: "fireThread1Block", userInfo: nil, repeats: false)
+                    let timer2 = NSTimer(fireDate: date, interval: 0, target: self, selector: "fireThread2Block", userInfo: nil, repeats: false)
+                    NSRunLoop.currentRunLoop().addTimer(timer1, forMode: NSDefaultRunLoopMode)
+                    NSRunLoop.currentRunLoop().addTimer(timer2, forMode: NSDefaultRunLoopMode)
+                }
+                it("should have executed only one block") {
+                    expect(self.oneBlockFired()).toEventually(beTruthy(), timeout: 2)
+                }
+            }
+        }
+    }
+}

--- a/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
@@ -1,5 +1,5 @@
 //
-//  RealmQueueManager.swift
+//  RealmQueueManagerTests.swift
 //  RealmResultsController
 //
 //  Created by Pol Quintana on 10/12/15.

--- a/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
@@ -41,14 +41,13 @@ class RealmQueueManagerSpec: QuickSpec {
     }
     
     func oneBlockFired() -> Bool {
-        let a = self.thread1BlockHasBeenFired || self.thread2BlockHasBeenFired
-        return a && !(self.thread1BlockHasBeenFired && self.thread2BlockHasBeenFired)
+        return self.thread1BlockHasBeenFired != self.thread2BlockHasBeenFired
     }
     
     override func spec() {
         context("addOperation(withBlock:)") {
             context("enqueued operations") {
-                let queueManager = RealmQueueManager(serial: false)
+                let queueManager = RealmQueueManager(sync: false)
                 var block1Executed = false
                 var block2Executed = false
                 let block1 = {
@@ -78,7 +77,7 @@ class RealmQueueManagerSpec: QuickSpec {
                 }
             }
             context("serial operations") {
-                let queueManager = RealmQueueManager(serial: true)
+                let queueManager = RealmQueueManager(sync: true)
                 var block1Executed = false
                 var block2Executed = false
                 let block1 = {

--- a/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmQueueManagerTests.swift
@@ -96,10 +96,10 @@ class RealmQueueManagerSpec: QuickSpec {
                     block1Executed = false
                     block2Executed = false
                 }
-                it("should have instantly executed the block 1") {
+                it("should execute block 1 synchronously") {
                     expect(block1Executed).to(beTruthy())
                 }
-                it("should have NOT enqueued the execution of the block 2") {
+                it("should execute block 2 synchronously") {
                     expect(block2Executed).to(beTruthy())
                 }
             }

--- a/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
@@ -481,8 +481,8 @@ class RealmResultsControllerSpec: QuickSpec {
 
         }
         describe("finishWriteTransaction()") {
-            var cacheSections: [Section<Task>]!
             context("If there are no pending changes") {
+                var cacheSections: [Section<Task>]!
                 beforeEach {
                     RRC.temporaryAdded.removeAll()
                     RRC.temporaryUpdated.removeAll()
@@ -492,29 +492,6 @@ class RealmResultsControllerSpec: QuickSpec {
                 it("Should return false") {
                     expect(RRC.pendingChanges()).to(beFalsy())
                     expect(RRC.cache?.sections).to(equal(cacheSections))
-                }
-            }
-            context("If the temporaryUpdated contains a MOVE") {
-                beforeEach {
-                    let sorts = [SortDescriptor(property: "name", ascending: true)]
-                    let request = RealmRequest<Task>(predicate: NSPredicate(value: true), realm: realm, sortDescriptors: sorts)
-                    RRC = try! RealmResultsController<Task, Task>(forTESTRequest: request, sectionKeyPath: nil) { $0 }
-                    RRC.delegate = RRCDelegate
-                    let task = Task()
-                    task.id = 12
-                    task.name = "bbb"
-                    let task2 = Task()
-                    task2.id = 13
-                    task2.name = "ccc"
-                    
-                    RRC.cache.reset([task, task2])
-                    task2.name = "aaa"
-                    RRC.temporaryUpdated.append(task2)
-                    let notif = NSNotification(name: "", object: [realm.path : [RealmChange]()])
-                    RRC.didReceiveRealmChanges(notif)
-                }
-                it("Should return false") {
-                    expect(RRC.pendingChanges()).to(beFalsy())
                 }
             }
         }

--- a/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
@@ -352,7 +352,7 @@ class RealmResultsControllerSpec: QuickSpec {
             beforeEach {
                 RRC = try! RealmResultsController<Task, Task>(forTESTRequest: request, sectionKeyPath: nil) { $0 }
                 RRC.delegate = RRCDelegate
-                RRC.queueManager = RealmQueueManager(serial: true)
+                RRC.queueManager = RealmQueueManager(sync: true)
             }
             
             context("it receives an object of another model") {

--- a/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
+++ b/Example/RealmResultsController-iOSTests/RealmResultsControllerTests.swift
@@ -89,14 +89,14 @@ class RealmResultsControllerSpec: QuickSpec {
             it("try to execute a block in main thread from a background queue") {
                 let queue = dispatch_queue_create("lock", DISPATCH_QUEUE_SERIAL)
                 dispatch_async(queue) {
-                    executeOnMainThread { }
+                    Threading.executeOnMainThread { }
                 }
             }
             
             it("try to execute a block in main thread from a background queue synced") {
                 let queue = dispatch_queue_create("lock", DISPATCH_QUEUE_SERIAL)
                 dispatch_async(queue) {
-                    executeOnMainThread(true) { }
+                    Threading.executeOnMainThread(true) { }
                 }
             }
             

--- a/RealmResultsController.xcodeproj/project.pbxproj
+++ b/RealmResultsController.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		C1565EC41B9711CF003B7ABD /* TestModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EBC1B970A9D003B7ABD /* TestModels.swift */; };
 		C1565EC51B971570003B7ABD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EBE1B970B12003B7ABD /* ViewController.swift */; };
 		C1565EC81B9717C3003B7ABD /* ViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EC01B970B1F003B7ABD /* ViewModels.swift */; };
+		C169FE991C189793001FC9EF /* RealmQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C169FE981C189793001FC9EF /* RealmQueueManager.swift */; };
 		C18B28851B9EEB620082F983 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C18B28831B9EEB620082F983 /* Realm.framework */; };
 		C18B28861B9EEB620082F983 /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C18B28831B9EEB620082F983 /* Realm.framework */; };
 		C18B28871B9EEB620082F983 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C18B28841B9EEB620082F983 /* RealmSwift.framework */; };
@@ -104,6 +105,7 @@
 		C1565EBC1B970A9D003B7ABD /* TestModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestModels.swift; sourceTree = "<group>"; };
 		C1565EBE1B970B12003B7ABD /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		C1565EC01B970B1F003B7ABD /* ViewModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModels.swift; sourceTree = "<group>"; };
+		C169FE981C189793001FC9EF /* RealmQueueManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmQueueManager.swift; path = Source/RealmQueueManager.swift; sourceTree = SOURCE_ROOT; };
 		C18B28831B9EEB620082F983 /* Realm.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Realm.framework; path = Carthage/Build/iOS/Realm.framework; sourceTree = "<group>"; };
 		C18B28841B9EEB620082F983 /* RealmSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RealmSwift.framework; path = Carthage/Build/iOS/RealmSwift.framework; sourceTree = "<group>"; };
 		C18C37611B72670F008DE6A6 /* RealmResultsController-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "RealmResultsController-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -219,6 +221,7 @@
 				C1D8710D1B72673E00C0ED18 /* RealmResultsCache.swift */,
 				C1D8710E1B72673E00C0ED18 /* RealmResultsController.swift */,
 				6A1010FB1B74A83600321CE6 /* RealmSection.swift */,
+				C169FE981C189793001FC9EF /* RealmQueueManager.swift */,
 				C133C9C51B97381600E51393 /* ObjectExtension.swift */,
 				6A29729B1BC55D6C004D9EC9 /* RealmThreadHelper.swift */,
 				C1A0028F1B9702C1000C0E8C /* Info.plist */,
@@ -426,6 +429,7 @@
 				C1565E8F1B970362003B7ABD /* RealmExtension.swift in Sources */,
 				C1565E961B970362003B7ABD /* RealmSection.swift in Sources */,
 				C1565E951B970362003B7ABD /* RealmResultsController.swift in Sources */,
+				C169FE991C189793001FC9EF /* RealmQueueManager.swift in Sources */,
 				C1565E911B970362003B7ABD /* RealmLogger.swift in Sources */,
 				C1565E921B970362003B7ABD /* RealmChange.swift in Sources */,
 				C1565E941B970362003B7ABD /* RealmResultsCache.swift in Sources */,

--- a/RealmResultsController.xcodeproj/project.pbxproj
+++ b/RealmResultsController.xcodeproj/project.pbxproj
@@ -35,18 +35,18 @@
 		C18C376A1B72670F008DE6A6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C18C37681B72670F008DE6A6 /* Main.storyboard */; };
 		C18C376C1B72670F008DE6A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C18C376B1B72670F008DE6A6 /* Assets.xcassets */; };
 		C18C376F1B72670F008DE6A6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C18C376D1B72670F008DE6A6 /* LaunchScreen.storyboard */; };
-		C19CCCAC1C19E44900F1BE8F /* RealmResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E549C91B73BE0A00341B47 /* RealmResultsControllerTests.swift */; };
-		C19CCCAD1C19E44900F1BE8F /* RealmResultsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68B20B1B735CFB007645A7 /* RealmResultsCacheTests.swift */; };
-		C19CCCAE1C19E44900F1BE8F /* RealmExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FF1B74C92200321CE6 /* RealmExtensionSpec.swift */; };
-		C19CCCAF1C19E44900F1BE8F /* RealmObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C149FA0A1BB1B96000392AB7 /* RealmObjectSpec.swift */; };
-		C19CCCB01C19E44900F1BE8F /* RealmSectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */; };
-		C19CCCB11C19E44900F1BE8F /* RealmNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */; };
-		C19CCCB21C19E44900F1BE8F /* RealmLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */; };
 		C1A0028E1B9702C1000C0E8C /* RealmResultsController-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A0028D1B9702C1000C0E8C /* RealmResultsController-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1A002951B9702C1000C0E8C /* RealmResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; };
 		C1A002A01B9702C2000C0E8C /* RealmResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; };
 		C1A002A11B9702C2000C0E8C /* RealmResultsController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C1A2DC0B1C19C65F00D2F0F0 /* RealmQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */; };
+		C1E4BF661C19F1B900450F14 /* RealmQueueManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2DC091C19C33F00D2F0F0 /* RealmQueueManagerTests.swift */; };
+		C1E4BF671C19F1CC00450F14 /* RealmLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */; };
+		C1E4BF681C19F1DB00450F14 /* RealmNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */; };
+		C1E4BF691C19F1E700450F14 /* RealmSectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */; };
+		C1E4BF6A1C19F1F400450F14 /* RealmObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C149FA0A1BB1B96000392AB7 /* RealmObjectSpec.swift */; };
+		C1E4BF6B1C19F20000450F14 /* RealmResultsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68B20B1B735CFB007645A7 /* RealmResultsCacheTests.swift */; };
+		C1E4BF6C1C19F20F00450F14 /* RealmExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FF1B74C92200321CE6 /* RealmExtensionSpec.swift */; };
+		C1E4BF6D1C19F23000450F14 /* RealmResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E549C91B73BE0A00341B47 /* RealmResultsControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -122,7 +122,7 @@
 		C1A0028F1B9702C1000C0E8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C1A002941B9702C1000C0E8C /* RealmResultsController-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RealmResultsController-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1A0029D1B9702C2000C0E8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmQueueManager.swift; sourceTree = "<group>"; };
+		C1A2DC091C19C33F00D2F0F0 /* RealmQueueManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmQueueManagerTests.swift; sourceTree = "<group>"; };
 		C1D8710A1B72673E00C0ED18 /* RealmExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmExtension.swift; path = ../../Source/RealmExtension.swift; sourceTree = "<group>"; };
 		C1D8710B1B72673E00C0ED18 /* RealmNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmNotification.swift; path = ../../Source/RealmNotification.swift; sourceTree = "<group>"; };
 		C1D8710C1B72673E00C0ED18 /* RealmRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmRequest.swift; path = ../../Source/RealmRequest.swift; sourceTree = "<group>"; };
@@ -243,7 +243,7 @@
 				6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */,
 				C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */,
 				C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */,
-				C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */,
+				C1A2DC091C19C33F00D2F0F0 /* RealmQueueManagerTests.swift */,
 				C127071C1B73944900B66698 /* RealmTestHelper.swift */,
 				6A5F153D1B736D5300250E29 /* test.realm */,
 				C1A0029D1B9702C2000C0E8C /* Info.plist */,
@@ -443,16 +443,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C19CCCAD1C19E44900F1BE8F /* RealmResultsCacheTests.swift in Sources */,
-				C19CCCB21C19E44900F1BE8F /* RealmLoggerTests.swift in Sources */,
+				C1E4BF6D1C19F23000450F14 /* RealmResultsControllerTests.swift in Sources */,
 				C1565EB41B970654003B7ABD /* RealmTestHelper.swift in Sources */,
-				C19CCCB11C19E44900F1BE8F /* RealmNotificationTests.swift in Sources */,
-				C19CCCB01C19E44900F1BE8F /* RealmSectionSpec.swift in Sources */,
-				C1A2DC0B1C19C65F00D2F0F0 /* RealmQueueManager.swift in Sources */,
-				C19CCCAC1C19E44900F1BE8F /* RealmResultsControllerTests.swift in Sources */,
-				C19CCCAE1C19E44900F1BE8F /* RealmExtensionSpec.swift in Sources */,
-				C19CCCAF1C19E44900F1BE8F /* RealmObjectSpec.swift in Sources */,
+				C1E4BF6C1C19F20F00450F14 /* RealmExtensionSpec.swift in Sources */,
+				C1E4BF6B1C19F20000450F14 /* RealmResultsCacheTests.swift in Sources */,
+				C1E4BF671C19F1CC00450F14 /* RealmLoggerTests.swift in Sources */,
+				C1E4BF691C19F1E700450F14 /* RealmSectionSpec.swift in Sources */,
+				C1E4BF681C19F1DB00450F14 /* RealmNotificationTests.swift in Sources */,
 				C1565EC41B9711CF003B7ABD /* TestModels.swift in Sources */,
+				C1E4BF6A1C19F1F400450F14 /* RealmObjectSpec.swift in Sources */,
+				C1E4BF661C19F1B900450F14 /* RealmQueueManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RealmResultsController.xcodeproj/project.pbxproj
+++ b/RealmResultsController.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		6A29729C1BC55D6C004D9EC9 /* RealmThreadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A29729B1BC55D6C004D9EC9 /* RealmThreadHelper.swift */; };
 		C133C9C61B97381600E51393 /* ObjectExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C133C9C51B97381600E51393 /* ObjectExtension.swift */; };
-		C149FA0B1BB1B96000392AB7 /* RealmObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C149FA0A1BB1B96000392AB7 /* RealmObjectSpec.swift */; };
 		C1565E8F1B970362003B7ABD /* RealmExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8710A1B72673E00C0ED18 /* RealmExtension.swift */; };
 		C1565E901B970362003B7ABD /* RealmNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8710B1B72673E00C0ED18 /* RealmNotification.swift */; };
 		C1565E911B970362003B7ABD /* RealmLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD7601B739E6300C5BF92 /* RealmLogger.swift */; };
@@ -18,16 +17,10 @@
 		C1565E941B970362003B7ABD /* RealmResultsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8710D1B72673E00C0ED18 /* RealmResultsCache.swift */; };
 		C1565E951B970362003B7ABD /* RealmResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D8710E1B72673E00C0ED18 /* RealmResultsController.swift */; };
 		C1565E961B970362003B7ABD /* RealmSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FB1B74A83600321CE6 /* RealmSection.swift */; };
-		C1565EAE1B970654003B7ABD /* RealmResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E549C91B73BE0A00341B47 /* RealmResultsControllerTests.swift */; };
-		C1565EAF1B970654003B7ABD /* RealmResultsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68B20B1B735CFB007645A7 /* RealmResultsCacheTests.swift */; };
-		C1565EB11B970654003B7ABD /* RealmSectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */; };
-		C1565EB21B970654003B7ABD /* RealmNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */; };
-		C1565EB31B970654003B7ABD /* RealmLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */; };
 		C1565EB41B970654003B7ABD /* RealmTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C127071C1B73944900B66698 /* RealmTestHelper.swift */; };
 		C1565EB61B970665003B7ABD /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A002461B96F790000C0E8C /* Quick.framework */; };
 		C1565EB71B970665003B7ABD /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A002471B96F790000C0E8C /* Nimble.framework */; };
 		C1565EB91B97074C003B7ABD /* test.realm in Resources */ = {isa = PBXBuildFile; fileRef = 6A5F153D1B736D5300250E29 /* test.realm */; };
-		C1565EC21B970EF5003B7ABD /* RealmExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FF1B74C92200321CE6 /* RealmExtensionSpec.swift */; };
 		C1565EC41B9711CF003B7ABD /* TestModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EBC1B970A9D003B7ABD /* TestModels.swift */; };
 		C1565EC51B971570003B7ABD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EBE1B970B12003B7ABD /* ViewController.swift */; };
 		C1565EC81B9717C3003B7ABD /* ViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1565EC01B970B1F003B7ABD /* ViewModels.swift */; };
@@ -42,10 +35,18 @@
 		C18C376A1B72670F008DE6A6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C18C37681B72670F008DE6A6 /* Main.storyboard */; };
 		C18C376C1B72670F008DE6A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C18C376B1B72670F008DE6A6 /* Assets.xcassets */; };
 		C18C376F1B72670F008DE6A6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C18C376D1B72670F008DE6A6 /* LaunchScreen.storyboard */; };
+		C19CCCAC1C19E44900F1BE8F /* RealmResultsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E549C91B73BE0A00341B47 /* RealmResultsControllerTests.swift */; };
+		C19CCCAD1C19E44900F1BE8F /* RealmResultsCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68B20B1B735CFB007645A7 /* RealmResultsCacheTests.swift */; };
+		C19CCCAE1C19E44900F1BE8F /* RealmExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FF1B74C92200321CE6 /* RealmExtensionSpec.swift */; };
+		C19CCCAF1C19E44900F1BE8F /* RealmObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C149FA0A1BB1B96000392AB7 /* RealmObjectSpec.swift */; };
+		C19CCCB01C19E44900F1BE8F /* RealmSectionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */; };
+		C19CCCB11C19E44900F1BE8F /* RealmNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */; };
+		C19CCCB21C19E44900F1BE8F /* RealmLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */; };
 		C1A0028E1B9702C1000C0E8C /* RealmResultsController-iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = C1A0028D1B9702C1000C0E8C /* RealmResultsController-iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C1A002951B9702C1000C0E8C /* RealmResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; };
 		C1A002A01B9702C2000C0E8C /* RealmResultsController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; };
 		C1A002A11B9702C2000C0E8C /* RealmResultsController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C1A0028B1B9702C1000C0E8C /* RealmResultsController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C1A2DC0B1C19C65F00D2F0F0 /* RealmQueueManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		C1A0028F1B9702C1000C0E8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C1A002941B9702C1000C0E8C /* RealmResultsController-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RealmResultsController-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1A0029D1B9702C2000C0E8C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmQueueManager.swift; sourceTree = "<group>"; };
 		C1D8710A1B72673E00C0ED18 /* RealmExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmExtension.swift; path = ../../Source/RealmExtension.swift; sourceTree = "<group>"; };
 		C1D8710B1B72673E00C0ED18 /* RealmNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmNotification.swift; path = ../../Source/RealmNotification.swift; sourceTree = "<group>"; };
 		C1D8710C1B72673E00C0ED18 /* RealmRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RealmRequest.swift; path = ../../Source/RealmRequest.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				6A1010FD1B74C5BB00321CE6 /* RealmSectionSpec.swift */,
 				C14CD75E1B7396D600C5BF92 /* RealmNotificationTests.swift */,
 				C14CD7621B739EE600C5BF92 /* RealmLoggerTests.swift */,
+				C1A2DC091C19C33F00D2F0F0 /* RealmQueueManager.swift */,
 				C127071C1B73944900B66698 /* RealmTestHelper.swift */,
 				6A5F153D1B736D5300250E29 /* test.realm */,
 				C1A0029D1B9702C2000C0E8C /* Info.plist */,
@@ -440,14 +443,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C1565EAE1B970654003B7ABD /* RealmResultsControllerTests.swift in Sources */,
+				C19CCCAD1C19E44900F1BE8F /* RealmResultsCacheTests.swift in Sources */,
+				C19CCCB21C19E44900F1BE8F /* RealmLoggerTests.swift in Sources */,
 				C1565EB41B970654003B7ABD /* RealmTestHelper.swift in Sources */,
-				C1565EB21B970654003B7ABD /* RealmNotificationTests.swift in Sources */,
-				C1565EB31B970654003B7ABD /* RealmLoggerTests.swift in Sources */,
-				C1565EC21B970EF5003B7ABD /* RealmExtensionSpec.swift in Sources */,
-				C149FA0B1BB1B96000392AB7 /* RealmObjectSpec.swift in Sources */,
-				C1565EB11B970654003B7ABD /* RealmSectionSpec.swift in Sources */,
-				C1565EAF1B970654003B7ABD /* RealmResultsCacheTests.swift in Sources */,
+				C19CCCB11C19E44900F1BE8F /* RealmNotificationTests.swift in Sources */,
+				C19CCCB01C19E44900F1BE8F /* RealmSectionSpec.swift in Sources */,
+				C1A2DC0B1C19C65F00D2F0F0 /* RealmQueueManager.swift in Sources */,
+				C19CCCAC1C19E44900F1BE8F /* RealmResultsControllerTests.swift in Sources */,
+				C19CCCAE1C19E44900F1BE8F /* RealmExtensionSpec.swift in Sources */,
+				C19CCCAF1C19E44900F1BE8F /* RealmObjectSpec.swift in Sources */,
 				C1565EC41B9711CF003B7ABD /* TestModels.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RealmResultsController.xcodeproj/xcshareddata/xcschemes/RealmResultsController-iOS.xcscheme
+++ b/RealmResultsController.xcodeproj/xcshareddata/xcschemes/RealmResultsController-iOS.xcscheme
@@ -26,7 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
@@ -49,6 +49,13 @@
             ReferencedContainer = "container:RealmResultsController.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TEST"
+            value = "true"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Source/RealmQueueManager.swift
+++ b/Source/RealmQueueManager.swift
@@ -12,6 +12,7 @@ struct RealmQueueManager {
     let operationQueue: NSOperationQueue = {
         let queue = NSOperationQueue()
         queue.maxConcurrentOperationCount = 1
+        queue.name = "com.RRC.\(arc4random_uniform(1000))"
         return queue
     }()
     

--- a/Source/RealmQueueManager.swift
+++ b/Source/RealmQueueManager.swift
@@ -1,0 +1,21 @@
+//
+//  RealmQueueManager.swift
+//  RealmResultsController
+//
+//  Created by Pol Quintana on 09/12/15.
+//  Copyright © 2015 Redbooth. All rights reserved.
+//
+
+import Foundation
+
+struct RealmQueueManager {
+    let operationQueue: NSOperationQueue = {
+        let queue = NSOperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
+    
+    func addOperation(withBlock block: ()->()) {
+        operationQueue.addOperationWithBlock(block)
+    }
+}

--- a/Source/RealmQueueManager.swift
+++ b/Source/RealmQueueManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct RealmQueueManager {
+    private var serial: Bool = false
     let operationQueue: NSOperationQueue = {
         let queue = NSOperationQueue()
         queue.maxConcurrentOperationCount = 1
@@ -16,8 +17,12 @@ struct RealmQueueManager {
         return queue
     }()
     
+    init(serial: Bool = false) {
+        self.serial = serial
+    }
+    
     func addOperation(withBlock block: ()->()) {
-        guard !Threading.isTesting else {
+        guard !serial else {
             block()
             return
         }

--- a/Source/RealmQueueManager.swift
+++ b/Source/RealmQueueManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct RealmQueueManager {
-    private var serial: Bool = false
+    private var sync: Bool = false
     let operationQueue: NSOperationQueue = {
         let queue = NSOperationQueue()
         queue.maxConcurrentOperationCount = 1
@@ -17,12 +17,12 @@ struct RealmQueueManager {
         return queue
     }()
     
-    init(serial: Bool = false) {
-        self.serial = serial
+    init(sync: Bool = false) {
+        self.sync = sync
     }
     
     func addOperation(withBlock block: ()->()) {
-        guard !serial else {
+        guard !sync else {
             block()
             return
         }

--- a/Source/RealmQueueManager.swift
+++ b/Source/RealmQueueManager.swift
@@ -17,6 +17,10 @@ struct RealmQueueManager {
     }()
     
     func addOperation(withBlock block: ()->()) {
+        guard !Threading.isTesting else {
+            block()
+            return
+        }
         operationQueue.addOperationWithBlock(block)
     }
 }

--- a/Source/RealmResultsController.swift
+++ b/Source/RealmResultsController.swift
@@ -70,7 +70,6 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     private(set) public var filter: (T -> Bool)?
     var mapper: T -> U
     var sectionKeyPath: String? = ""
-    var backgroundQueue = dispatch_queue_create("com.RRC.\(arc4random_uniform(1000))", DISPATCH_QUEUE_SERIAL)
     var queueManager: RealmQueueManager = RealmQueueManager()
     var temporaryAdded: [T] = []
     var temporaryUpdated: [T] = []
@@ -239,32 +238,32 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     //MARK: Cache delegate
     
     func didInsert<T: Object>(object: T, indexPath: NSIndexPath) {
-        executeOnMainThread {
+        Threading.executeOnMainThread {
             self.delegate?.didChangeObject(self, object: object, oldIndexPath: indexPath, newIndexPath: indexPath, changeType: .Insert)
         }
     }
     
     func didUpdate<T: Object>(object: T, oldIndexPath: NSIndexPath, newIndexPath: NSIndexPath, changeType: RealmResultsChangeType) {
-        executeOnMainThread {
+        Threading.executeOnMainThread {
             self.delegate?.didChangeObject(self, object: object, oldIndexPath: oldIndexPath, newIndexPath: newIndexPath, changeType: changeType)
         }
     }
     
     func didDelete<T: Object>(object: T, indexPath: NSIndexPath) {
-        executeOnMainThread {
+        Threading.executeOnMainThread {
             self.delegate?.didChangeObject(self, object: object, oldIndexPath: indexPath, newIndexPath: indexPath, changeType: .Delete)
         }
     }
     
     func didInsertSection<T : Object>(section: Section<T>, index: Int) {
         if populating { return }
-        executeOnMainThread {
+        Threading.executeOnMainThread {
             self.delegate?.didChangeSection(self, section: self.realmSectionMapper(section), index: index, changeType: .Insert)
         }
     }
     
     func didDeleteSection<T : Object>(section: Section<T>, index: Int) {
-        executeOnMainThread {
+        Threading.executeOnMainThread {
             self.delegate?.didChangeSection(self, section: self.realmSectionMapper(section), index: index, changeType: .Delete)
         }
     }
@@ -282,10 +281,8 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
             where notificationObject.keys.first == request.realm.path,
             let objects = notificationObject[self.request.realm.path] else { return }
         queueManager.addOperation {
-            self.executeOnCorrectThread {
-                self.refetchObjects(objects)
-                self.finishWriteTransaction()
-            }
+            self.refetchObjects(objects)
+            self.finishWriteTransaction()
         }
         
     }
@@ -302,7 +299,7 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
             let passesPredicate = self.request.predicate.evaluateWithObject(object.mirror as! T)
             
             if let filter = filter {
-                executeOnMainThread(true) {
+                Threading.executeOnMainThread(true) {
                     passesFilter = filter(object.mirror as! T)
                 }
             }
@@ -329,7 +326,7 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     
     private func finishWriteTransaction() {
         if !pendingChanges() { return }
-        executeOnMainThread(true) {
+        Threading.executeOnMainThread(true) {
             self.delegate?.willChangeResults(self)
         }
         var objectsToMove: [T] = []
@@ -346,15 +343,8 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
         temporaryAdded.removeAll()
         temporaryDeleted.removeAll()
         temporaryUpdated.removeAll()
-        executeOnMainThread(true) {
+        Threading.executeOnMainThread(true) {
             self.delegate?.didChangeResults(self)
         }
-    }
-    
-    
-    //MARK: Thread management
-    
-    func executeOnCorrectThread(block: ()->()) {
-        _test ? dispatch_sync(backgroundQueue, block) : dispatch_async(backgroundQueue, block)
     }
 }

--- a/Source/RealmThreadHelper.swift
+++ b/Source/RealmThreadHelper.swift
@@ -10,6 +10,11 @@ import Foundation
 
 
 struct Threading {
+    static let isTesting: Bool = {
+        let environment = NSProcessInfo.processInfo().environment
+        return environment["TEST"] != nil
+    }()
+    
     /**
      Execute a block in the main thread.
      If we are already in it, just execute. If not, do a dispatch to execute it.
@@ -20,8 +25,9 @@ struct Threading {
      - parameter block: Block to execute
      */
     static func executeOnMainThread(sync: Bool = false, block: ()->()) {
-        if NSThread.currentThread().isMainThread {
+        guard !NSThread.currentThread().isMainThread else {
             block()
+            return
         }
         executeOnQueue(dispatch_get_main_queue(), sync: sync, block: block)
     }

--- a/Source/RealmThreadHelper.swift
+++ b/Source/RealmThreadHelper.swift
@@ -9,23 +9,32 @@
 import Foundation
 
 
-/**
-Execute a block in the main thread. 
-If we are already in it, just execute. If not, do a dispatch to execute it.
-
-You can select if the execution should be sync or async (careful with deadlocks!!)
-
-- parameter sync:  Bool, true if the execution should be dispatch_sync, false for dispatch_async
-- parameter block: Block to execute
-*/
-func executeOnMainThread(sync: Bool = false, block: ()->()) {
-    if NSThread.currentThread().isMainThread {
-        block()
+struct Threading {
+    /**
+     Execute a block in the main thread.
+     If we are already in it, just execute. If not, do a dispatch to execute it.
+     
+     You can select if the execution should be sync or async (careful with deadlocks!!)
+     
+     - parameter sync:  Bool, true if the execution should be dispatch_sync, false for dispatch_async
+     - parameter block: Block to execute
+     */
+    static func executeOnMainThread(sync: Bool = false, block: ()->()) {
+        if NSThread.currentThread().isMainThread {
+            block()
+        }
+        executeOnQueue(dispatch_get_main_queue(), sync: sync, block: block)
     }
-    else if sync {
-        dispatch_sync(dispatch_get_main_queue(), block)
-    }
-    else {
-        dispatch_async(dispatch_get_main_queue(), block)
+    
+    /**
+     Execute a block in the passed queue.
+     
+     You can select if the execution should be sync or async (careful with deadlocks!!)
+     
+     - parameter sync:  Bool, true if the execution should be dispatch_sync, false for dispatch_async
+     - parameter block: Block to execute
+     */
+    static func executeOnQueue(queue: dispatch_queue_t, sync: Bool = false, block: ()->()) {
+        sync ? dispatch_sync(queue, block) : dispatch_async(queue, block)
     }
 }

--- a/Source/RealmThreadHelper.swift
+++ b/Source/RealmThreadHelper.swift
@@ -41,6 +41,6 @@ struct Threading {
      - parameter block: Block to execute
      */
     static func executeOnQueue(queue: dispatch_queue_t, sync: Bool = false, block: ()->()) {
-        sync ? dispatch_sync(queue, block) : dispatch_async(queue, block)
+        sync && !isTesting ? dispatch_sync(queue, block) : dispatch_async(queue, block)
     }
 }

--- a/Source/RealmThreadHelper.swift
+++ b/Source/RealmThreadHelper.swift
@@ -41,6 +41,7 @@ struct Threading {
      - parameter block: Block to execute
      */
     static func executeOnQueue(queue: dispatch_queue_t, sync: Bool = false, block: ()->()) {
-        sync && !isTesting ? dispatch_sync(queue, block) : dispatch_async(queue, block)
+        guard !isTesting else { return dispatch_sync(queue, block) }
+        sync ? dispatch_sync(queue, block) : dispatch_async(queue, block)
     }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

There was an scenario where if the RRC was being accessed from different threads, it was causing unordered calls to `willChangeResults` and `didChangeResults`, and this was causing a crash on the collectionView/tableView.

Added `RealmQueueManager`, which is a wrapper around NSOperationQueue, that is going to prevent this by only executing 1 concurrent operation at a time.

Also added a Environment Variable that is going to prevent the operations to be enqueued while running tests
#### :ghost: GIF

![](http://i.giphy.com/11xTvLtwCEA2sg.gif)
