### PR TITLE
Defending against section.deleteOutdatedObject returning a -1

### DIFF
--- a/Example/RealmResultsController-iOSTests/RealmSectionSpec.swift
+++ b/Example/RealmResultsController-iOSTests/RealmSectionSpec.swift
@@ -98,8 +98,8 @@ class SectionSpec: QuickSpec {
                     anotherTask = Task()
                     index = section.delete(anotherTask)
                 }
-                it("returns index -1") {
-                    expect(index).to(equal(-1))
+                it("returns index NotFound") {
+                    expect(index).to(equal(NotFound))
                 }
             }
         }
@@ -130,8 +130,8 @@ class SectionSpec: QuickSpec {
                     anotherTask = Task()
                     index = section.deleteOutdatedObject(anotherTask)
                 }
-                it("returns index -1") {
-                    expect(index).to(equal(-1))
+                it("returns index NotFound") {
+                    expect(index).to(equal(NotFound))
                 }
             }
         }

--- a/Example/RealmResultsController-iOSTests/RealmSectionSpec.swift
+++ b/Example/RealmResultsController-iOSTests/RealmSectionSpec.swift
@@ -98,8 +98,8 @@ class SectionSpec: QuickSpec {
                     anotherTask = Task()
                     index = section.delete(anotherTask)
                 }
-                it("returns index NotFound") {
-                    expect(index).to(equal(NotFound))
+                it("returns index nil") {
+                    expect(index).to(beNil())
                 }
             }
         }
@@ -130,8 +130,8 @@ class SectionSpec: QuickSpec {
                     anotherTask = Task()
                     index = section.deleteOutdatedObject(anotherTask)
                 }
-                it("returns index NotFound") {
-                    expect(index).to(equal(NotFound))
+                it("returns index nil") {
+                    expect(index).to(beNil())
                 }
             }
         }

--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -120,6 +120,7 @@ class RealmResultsCache<T: Object> {
             guard let section = sectionForOutdateObject(object),
                 let sectionIndex = indexForSection(section) else { continue }
             let index = section.deleteOutdatedObject(object)
+            guard index != -1 else { continue }
             let indexPath = NSIndexPath(forRow: index, inSection: sectionIndex)
             
             temporalDeletions.append(object)

--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -9,8 +9,6 @@
 import Foundation
 import RealmSwift
 
-let NotFound: Int = -1
-
 enum RealmCacheUpdateType: String {
     case Move
     case Update
@@ -110,8 +108,7 @@ class RealmResultsCache<T: Object> {
         var outdated: [T] = []
         for object in objects {
             guard let section = sectionForOutdateObject(object) else { continue }
-            let index = section.indexForOutdatedObject(object)
-            guard index != NotFound,
+            guard let index = section.indexForOutdatedObject(object),
                 let object = section.objects.objectAtIndex(index) as? T else { continue }
             outdated.append(object)
         }
@@ -121,8 +118,7 @@ class RealmResultsCache<T: Object> {
         for object in mirrorsArray {
             guard let section = sectionForOutdateObject(object),
                 let sectionIndex = indexForSection(section) else { continue }
-            let index = section.deleteOutdatedObject(object)
-            guard index != NotFound else { continue }
+            guard let index = section.deleteOutdatedObject(object) else { continue }
             let indexPath = NSIndexPath(forRow: index, inSection: sectionIndex)
             
             temporalDeletions.append(object)
@@ -140,9 +136,7 @@ class RealmResultsCache<T: Object> {
         for object in objects {
             guard let oldSection = sectionForOutdateObject(object),
                 let oldSectionIndex = indexForSection(oldSection) else { continue }
-            let oldIndexRow = oldSection.indexForOutdatedObject(object)
-            
-            if oldIndexRow == NotFound {
+            guard let oldIndexRow = oldSection.indexForOutdatedObject(object) else {
                 insert([object])
                 continue
             }
@@ -187,7 +181,7 @@ class RealmResultsCache<T: Object> {
     
     private func sectionForOutdateObject(object: T) -> Section<T>? {
         for section in sections {
-            if section.indexForOutdatedObject(object) != NotFound {
+            if let _ = section.indexForOutdatedObject(object) {
                 return section
             }
         }
@@ -222,8 +216,7 @@ class RealmResultsCache<T: Object> {
         guard let outdatedCopy = oldSection.outdatedObject(object) else { return .Insert }
         
         //Indexes
-        let oldIndexRow = oldSection.delete(outdatedCopy)
-        if oldIndexRow == NotFound { return .Insert }
+        guard let oldIndexRow = oldSection.delete(outdatedCopy) else { return .Insert }
         let newIndexRow = newSection.insertSorted(object)
 
         //Restore

--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -9,6 +9,8 @@
 import Foundation
 import RealmSwift
 
+let NotFound: Int = -1
+
 enum RealmCacheUpdateType: String {
     case Move
     case Update
@@ -109,7 +111,7 @@ class RealmResultsCache<T: Object> {
         for object in objects {
             guard let section = sectionForOutdateObject(object) else { continue }
             let index = section.indexForOutdatedObject(object)
-            guard index != -1,
+            guard index != NotFound,
                 let object = section.objects.objectAtIndex(index) as? T else { continue }
             outdated.append(object)
         }
@@ -120,7 +122,7 @@ class RealmResultsCache<T: Object> {
             guard let section = sectionForOutdateObject(object),
                 let sectionIndex = indexForSection(section) else { continue }
             let index = section.deleteOutdatedObject(object)
-            guard index != -1 else { continue }
+            guard index != NotFound else { continue }
             let indexPath = NSIndexPath(forRow: index, inSection: sectionIndex)
             
             temporalDeletions.append(object)
@@ -140,7 +142,7 @@ class RealmResultsCache<T: Object> {
                 let oldSectionIndex = indexForSection(oldSection) else { continue }
             let oldIndexRow = oldSection.indexForOutdatedObject(object)
             
-            if oldIndexRow == -1 {
+            if oldIndexRow == NotFound {
                 insert([object])
                 continue
             }
@@ -185,7 +187,7 @@ class RealmResultsCache<T: Object> {
     
     private func sectionForOutdateObject(object: T) -> Section<T>? {
         for section in sections {
-            if section.indexForOutdatedObject(object) != -1 {
+            if section.indexForOutdatedObject(object) != NotFound {
                 return section
             }
         }
@@ -221,7 +223,7 @@ class RealmResultsCache<T: Object> {
         
         //Indexes
         let oldIndexRow = oldSection.delete(outdatedCopy)
-        if oldIndexRow == -1 { return .Insert }
+        if oldIndexRow == NotFound { return .Insert }
         let newIndexRow = newSection.insertSorted(object)
 
         //Restore

--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -135,8 +135,8 @@ class RealmResultsCache<T: Object> {
     func update(objects: [T]) {
         for object in objects {
             guard let oldSection = sectionForOutdateObject(object),
-                let oldSectionIndex = indexForSection(oldSection) else { continue }
-            guard let oldIndexRow = oldSection.indexForOutdatedObject(object) else {
+                let oldSectionIndex = indexForSection(oldSection),
+                let oldIndexRow = oldSection.indexForOutdatedObject(object) else {
                 insert([object])
                 continue
             }

--- a/Source/RealmSection.swift
+++ b/Source/RealmSection.swift
@@ -38,22 +38,22 @@ class Section<T: Object> : NSObject {
         return objects.indexOfObject(object)
     }
     
-    func delete(object: T) -> Int {
+    func delete(object: T) -> Int? {
         let index = objects.indexOfObject(object)
         if index < objects.count {
             objects.removeObject(object)
             return index
         }
-        return NotFound
+        return nil
     }
     
     //MARK: Outdated objects
     
-    func deleteOutdatedObject(object: T) -> Int {
+    func deleteOutdatedObject(object: T) -> Int? {
         if let object = outdatedObject(object) {
             return delete(object)
         }
-        return NotFound
+        return nil
     }
     
     func outdatedObject(object: T) -> T? {
@@ -62,12 +62,12 @@ class Section<T: Object> : NSObject {
         return objectForPrimaryKey(primaryKeyValue)
     }
     
-    func indexForOutdatedObject(object: T) -> Int {
+    func indexForOutdatedObject(object: T) -> Int? {
         let objectToDelete: T? = outdatedObject(object)
         if let obj = objectToDelete {
             return objects.indexOfObject(obj)
         }
-        return NotFound
+        return nil
     }
     
     //MARK: Helpers

--- a/Source/RealmSection.swift
+++ b/Source/RealmSection.swift
@@ -44,7 +44,7 @@ class Section<T: Object> : NSObject {
             objects.removeObject(object)
             return index
         }
-        return -1
+        return NotFound
     }
     
     //MARK: Outdated objects
@@ -53,7 +53,7 @@ class Section<T: Object> : NSObject {
         if let object = outdatedObject(object) {
             return delete(object)
         }
-        return -1
+        return NotFound
     }
     
     func outdatedObject(object: T) -> T? {
@@ -67,7 +67,7 @@ class Section<T: Object> : NSObject {
         if let obj = objectToDelete {
             return objects.indexOfObject(obj)
         }
-        return -1
+        return NotFound
     }
     
     //MARK: Helpers


### PR DESCRIPTION
#### :tophat: What? Why?
- Defending against the possibility that section.deleteOutdatedObject returns a -1 if it does not find the object in the cache:
  - Returning nil instead of `-1` when the object is not found 
#### :ghost: GIF

![](http://i.giphy.com/ofrnsIuGVpW4o.gif)
