### PR TITLE
Fix incorrect thread access

### DIFF
--- a/Source/RealmResultsController.swift
+++ b/Source/RealmResultsController.swift
@@ -296,10 +296,11 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
             }
             
             var passesFilter = true
-            let passesPredicate = self.request.predicate.evaluateWithObject(mirrorObject)
+            var passesPredicate = true
             
-            if let filter = filter {
-                Threading.executeOnMainThread(true) {
+            Threading.executeOnMainThread(true) {
+                passesPredicate = self.request.predicate.evaluateWithObject(mirrorObject)
+                if let filter = self.filter {
                     passesFilter = filter(mirrorObject)
                 }
             }

--- a/Source/RealmSection.swift
+++ b/Source/RealmSection.swift
@@ -34,7 +34,9 @@ class Section<T: Object> : NSObject {
     
     func insertSorted(object: T) -> Int {
         objects.addObject(object)
-        objects.sortUsingDescriptors(sortDescriptors)
+        Threading.executeOnMainThread(true) {
+            self.objects.sortUsingDescriptors(self.sortDescriptors)
+        }
         return objects.indexOfObject(object)
     }
     
@@ -74,11 +76,12 @@ class Section<T: Object> : NSObject {
     
     func objectForPrimaryKey(value: AnyObject) -> T? {
         for object in objects {
-            guard let primaryKey = T.primaryKey(),
-                let primaryKeyValue = object.valueForKey(primaryKey) else {
-                    continue
+            guard let primaryKey = T.primaryKey() else { continue }
+            var primaryKeyValue: AnyObject?
+            Threading.executeOnMainThread(true) {
+                primaryKeyValue = object.valueForKey(primaryKey)
             }
-            if primaryKeyValue.isEqual(value){
+            if value.isEqual(primaryKeyValue) {
                 return (object as? T)
             }
         }


### PR DESCRIPTION
These method calls are causing `IncorrectThreadException`

```
libc++abi.dylib: terminating with uncaught exception of type
realm::IncorrectThreadException: Realm accessed from incorrect thread.
```
