### PR TITLE
Relationships mirroring

### DIFF
--- a/Source/RealmExtension.swift
+++ b/Source/RealmExtension.swift
@@ -185,27 +185,3 @@ extension Results {
         return array
     }
 }
-
-/**
-Create a mirror of an object <T: Object>.
-This mirror is not added to any Raelm so it is 
-"thread safe" as long as you don't try to access 
-any relationship from a background thread
-
-- parameter object Original object (T) to mirror
-
-- returns a copy of the original object (T) but not included in any realm
-*/
-func getMirror<T: Object>(object: T) -> T {
-    let newObject = (object as Object).dynamicType.init()
-    let mirror = Mirror(reflecting: object)
-    for c in mirror.children.enumerate() {
-        guard let key = c.1.0
-            where !key.hasSuffix(".storage") else { continue }
-        let value = (object as Object).valueForKey(key)
-        guard let v = value else { continue }
-        (newObject as Object).setValue(v, forKey: key)
-    }
-    return newObject as! T
-}
-

--- a/Source/RealmLogger.swift
+++ b/Source/RealmLogger.swift
@@ -10,16 +10,6 @@ import Foundation
 import RealmSwift
 
 /**
- Public extension for Object lets overriding to specify the custom
- Object-to-Mirror translation in case you need the relationship mirroring.
- */
-public extension Object {
-  public func rrc_mapObjectToMirror() -> Object {
-    return getMirror(self)
-  }
-}
-
-/**
  Internal RealmResultsController class
  In charge of listen to Realm notifications and notify the RRCs when finished
  A logger is associated with one and only one Realm.
@@ -81,7 +71,7 @@ class RealmLogger {
     - parameter action Action that was performed on that object
     */
     func addObject<T: Object>(object: T, action: RealmAction) {
-        let realmChange = RealmChange(type: (object as Object).dynamicType, action: action, mirror: object.rrc_mapObjectToMirror())
+        let realmChange = RealmChange(type: (object as Object).dynamicType, action: action, mirror: object.getMirror())
         temporary.append(realmChange)
     }
     

--- a/Source/RealmLogger.swift
+++ b/Source/RealmLogger.swift
@@ -10,6 +10,16 @@ import Foundation
 import RealmSwift
 
 /**
+ Public extension for Object lets overriding to specify the custom
+ Object-to-Mirror translation in case you need the relationship mirroring.
+ */
+public extension Object {
+  public func rrc_mapObjectToMirror() -> Object {
+    return getMirror(self)
+  }
+}
+
+/**
  Internal RealmResultsController class
  In charge of listen to Realm notifications and notify the RRCs when finished
  A logger is associated with one and only one Realm.
@@ -71,7 +81,7 @@ class RealmLogger {
     - parameter action Action that was performed on that object
     */
     func addObject<T: Object>(object: T, action: RealmAction) {
-        let realmChange = RealmChange(type: (object as Object).dynamicType, action: action, mirror: getMirror(object))
+        let realmChange = RealmChange(type: (object as Object).dynamicType, action: action, mirror: object.rrc_mapObjectToMirror())
         temporary.append(realmChange)
     }
     

--- a/Source/RealmResultsController.swift
+++ b/Source/RealmResultsController.swift
@@ -184,7 +184,7 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     */
     public func performFetch() {
         populating = true
-        var objects = self.request.execute().toArray().map(getMirror)
+        var objects = self.request.execute().toArray().map{ $0.getMirror() as! T }
         if let filter = filter {
             objects = objects.filter(filter)
         }


### PR DESCRIPTION
Public overridable Object's extension for relationship mirroring to be able.

Example:

```
extension Product {
  override func rrc_mapObjectToMirror() -> Product {
    let clone = super.rrc_mapObjectToMirror() as! Product
    clone.category = self.category?.rrc_mapObjectToMirror() as? Category
    return clone
  }
}
```
