### PR TITLE
Support for descending sort when use grouping

### DIFF
--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -268,7 +268,9 @@ class RealmResultsCache<T: Object> {
     Sort the sections using the Given KeyPath
     */
     private func sortSections() {
-        sections.sortInPlace { $0.keyPath.localizedCaseInsensitiveCompare($1.keyPath) == NSComparisonResult.OrderedAscending }
+        guard let sortd =  request.sortDescriptors.first else { return }
+        let comparator: NSComparisonResult = sortd.ascending ? .OrderedAscending : .OrderedDescending
+        sections.sortInPlace { $0.keyPath.localizedCaseInsensitiveCompare($1.keyPath) == comparator }
     }
     
     /**

--- a/Source/RealmResultsCache.swift
+++ b/Source/RealmResultsCache.swift
@@ -41,7 +41,7 @@ so calling only `delete` will change the cache but not call the delegate.
 */
 class RealmResultsCache<T: Object> {
     var request: RealmRequest<T>
-    var sectionSorter: SortDescriptor?
+    var sectionKeyPath: String? = ""
     var sections: [Section<T>] = []
     let defaultKeyPathValue = "default"
     weak var delegate: RealmResultsCacheDelegate?
@@ -51,9 +51,9 @@ class RealmResultsCache<T: Object> {
     
     
     //MARK: Initializer
-    init(request: RealmRequest<T>, sectionSorter: SortDescriptor?) {
+    init(request: RealmRequest<T>, sectionKeyPath: String?) {
         self.request = request
-        self.sectionSorter = sectionSorter
+        self.sectionKeyPath = sectionKeyPath
     }
     
 
@@ -235,7 +235,7 @@ class RealmResultsCache<T: Object> {
     
     func keyPathForObject(object: T) -> String {
         var keyPathValue = defaultKeyPathValue
-        if let keyPath = sectionSorter?.property {
+        if let keyPath = sectionKeyPath {
             if keyPath.isEmpty { return  defaultKeyPathValue }
             Threading.executeOnMainThread(true) {
                 if let objectKeyPathValue = object.valueForKeyPath(keyPath) {
@@ -268,15 +268,7 @@ class RealmResultsCache<T: Object> {
     Sort the sections using the Given KeyPath
     */
     private func sortSections() {
-        let comparator: NSComparisonResult
-        if let ascending = sectionSorter?.ascending where ascending {
-            comparator = .OrderedAscending
-        }
-        else {
-            comparator = .OrderedDescending
-        }
-        
-        sections.sortInPlace { $0.keyPath.localizedCaseInsensitiveCompare($1.keyPath) == comparator }
+        sections.sortInPlace { $0.keyPath.localizedCaseInsensitiveCompare($1.keyPath) == NSComparisonResult.OrderedAscending }
     }
     
     /**

--- a/Source/RealmResultsController.swift
+++ b/Source/RealmResultsController.swift
@@ -69,7 +69,6 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     private(set) public var request: RealmRequest<T>
     private(set) public var filter: (T -> Bool)?
     var mapper: T -> U
-    var sectionKeyPath: String? = ""
     var queueManager: RealmQueueManager = RealmQueueManager()
     var temporaryAdded: [T] = []
     var temporaryUpdated: [T] = []
@@ -99,35 +98,35 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     //MARK: Initializers
 
     /**
-    Create a RealmResultsController with a Request, a SectionKeypath to group the results and a mapper.
+    Create a RealmResultsController with a Request, choose whether you want to group the results and a mapper.
     This init NEEDS a mapper, and all the Realm Models (T) will be transformed using the mapper
     to objects of type (U). Done this way to avoid using Realm objects that are not thread safe.
     And to decouple the Model layer of the View Layer.
     If you want the RRC to return Realm objects that are thread safe, you should use the init
     that doesn't require a mapper.
     
-    NOTE: If sectionKeyPath is used, it must be equal to the property used in the first SortDescriptor
-    of the RealmRequest. If not, RRC will throw an error.
+    NOTE: If you want to group the results, you must specify at least one sorter, because the first of them will be used for grouping. If not, RRC will throw an error.
     NOTE2: Realm does not support sorting by KeyPaths, so you must only use properties of the model
     you want to fetch and not KeyPath to any relationship
     NOTE3: The RealmRequest needs at least one SortDescriptor
     
     - param: request        Request to fetch objects
-    - param: sectionKeyPath KeyPath to group the results by sections
+    - param: group          Boolean, should RRC group the results or not
     - param: mapper         Mapper to map the results.
     
     - returns: Self
     */
-    public init(request: RealmRequest<T>, sectionKeyPath: String? ,mapper: T -> U, filter: (T -> Bool)? = nil) throws {
+    public init(request: RealmRequest<T>, group: Bool, mapper: T -> U, filter: (T -> Bool)? = nil) throws {
+        let sectionSorter = group ? request.sortDescriptors.first : nil
+        
         self.request = request
         self.mapper = mapper
-        self.sectionKeyPath = sectionKeyPath
-        self.cache = RealmResultsCache<T>(request: request, sectionKeyPath: sectionKeyPath)
+        self.cache = RealmResultsCache<T>(request: request, sectionSorter: sectionSorter)
         self.filter = filter
         if sortDescriptorsAreEmpty(request.sortDescriptors) {
             throw RRCError.EmptySortDescriptors
         }
-        if !keyPathIsValid(sectionKeyPath, sorts: request.sortDescriptors) {
+        if group && sectionSorter == nil {
             throw RRCError.InvalidKeyPath
         }
         self.cache?.delegate = self
@@ -141,21 +140,20 @@ public class RealmResultsController<T: Object, U> : RealmResultsCacheDelegate {
     All objects sent to the delegate of the RRC will be of the model type but
     they will be "mirrors", i.e. they don't belong to any Realm DB.
     
-    NOTE: If sectionKeyPath is used, it must be equal to the property used in the first SortDescriptor
-    of the RealmRequest. If not, RRC will throw an error
+    NOTE: If you want to group the results, you must specify at least one sorter, because the first of them will be used for grouping. If not, RRC will throw an error.
     NOTE2: The RealmRequest needs at least one SortDescriptor
     
     - param: request        Request to fetch objects
-    - param: sectionKeyPath keyPath to group the results of the request
+     - param: group          Boolean, should RRC group the results or not
     
     - returns: self
     */
-    public convenience init(request: RealmRequest<T>, sectionKeyPath: String?) throws {
-        try self.init(request: request, sectionKeyPath: sectionKeyPath, mapper: {$0 as! U})
+    public convenience init(request: RealmRequest<T>, group: Bool) throws {
+        try self.init(request: request, group: group, mapper: {$0 as! U})
     }
     
-    internal convenience init(forTESTRequest request: RealmRequest<T>, sectionKeyPath: String?, mapper: (T)->(U)) throws {
-        try self.init(request: request, sectionKeyPath: sectionKeyPath, mapper: mapper)
+    internal convenience init(forTESTRequest request: RealmRequest<T>, group: Bool, mapper: (T)->(U)) throws {
+        try self.init(request: request, group: group, mapper: mapper)
         self._test = true
     }
     


### PR DESCRIPTION
Made public just a boolean, whether or not use the grouping.
If true, then use the first sorter as grouping path, automatically.
